### PR TITLE
Remove Django 1.8 compat for future django needs

### DIFF
--- a/django_cryptography/fields.py
+++ b/django_cryptography/fields.py
@@ -124,8 +124,7 @@ class EncryptedMixin(object):
 
     def check(self, **kwargs):
         errors = super(EncryptedMixin, self).check(**kwargs)
-        # Django 1.8 compatibility for `self.rel`
-        if getattr(self, 'remote_field', getattr(self, 'rel', None)):
+        if getattr(self, 'remote_field', None):
             errors.append(
                 checks.Error(
                     'Base field for encrypted cannot be a related field.',


### PR DESCRIPTION
Removes Django 1.8 compatibility, but if we go back upstream it'll re-appear.

This could never be called in code since we have 'remote_field', but just removing it to make our code clean of deprecation warnings.

